### PR TITLE
Altering navbar for better small screen display

### DIFF
--- a/_includes/nav2.html
+++ b/_includes/nav2.html
@@ -1,27 +1,28 @@
 <!-- Navigation -->
 <nav>
     <div class="container">
-
-        <div class='col-md-9'>
+      <div class="row">
+        <div class='col-xs-5 col-sm-6 col-lg-8'>
             <a href="#page-top">
-                <img class='nav-logo' src='https://raw.githubusercontent.com/resbaz/resbaz-2016-02-01/gh-pages/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
+                <img class='nav-logo' src='{{site.baseurl}}/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
             </a>
         </div>
-        <div class='col-md-3'>
+        <div class='col-xs-7 col-sm-6 col-lg-4'>
             <ul class="nav navbar-nav navbar-right nav-list">
-                <li class="hidden">
+                <li class="hidden pull-left">
                     <a href="#page-top"></a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#about">About</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#locations">Locations</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#contact">Contact</a>
                 </li>
             </ul>
         </div>
+      </div>
     </div>
 </nav>

--- a/_posts/2016-02-01-brisbane.html
+++ b/_posts/2016-02-01-brisbane.html
@@ -84,12 +84,12 @@ sponsors:
 <nav>
     <div class="container">
 
-        <div class='col-md-8'>
-            <a href="https://2016-02-01.resbaz.com/">
-                <img class='nav-logo' src='https://raw.githubusercontent.com/resbaz/resbaz-2016-02-01/gh-pages/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
+        <div class='col-sm-6'>
+            <a href="{{site.baseurl}}/">
+                <img class='nav-logo' src='{{site.baseurl}}/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
             </a>
         </div>
-        <div class='col-md-4'>
+        <div class='col-sm-6'>
             <ul class="nav navbar-nav navbar-right nav-list">
                 <li class="hidden">
                     <a href="#page-top"></a>

--- a/_posts/2016-02-01-melbourne.html
+++ b/_posts/2016-02-01-melbourne.html
@@ -147,32 +147,36 @@ sponsors:
 <!-- Navigation -->
 <nav>
     <div class="container">
-        <div class='col-md-6'>
-            <a href="https://2016-02-01.resbaz.com/">
-                <img class='nav-logo' src='https://raw.githubusercontent.com/resbaz/resbaz-2016-02-01/gh-pages/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
+      <div class="row">
+        <div class='col-xs-2 col-sm-3 col-lg-6'>
+            <a class="hidden-xs" href="{{site.baseurl}}/">
+                <img class='nav-logo' src='{{site.baseurl}}/img/resbaz_logos/ResBaz_transparent_cropped.png'></img>
+            </a>
+            <a class="visible-xs-inline-block btn navbar-btn" href="{{site.baseurl}}/">
+                <i class="glyphicon glyphicon-home"></i>
             </a>
         </div>
-        <div class='col-md-6'>
+        <div class='col-xs-10 col-sm-9 col-lg-6'>
             <ul class="nav navbar-nav navbar-right nav-list">
-                <li class="hidden">
+                <li class="hidden pull-left">
                     <a href="#page-top"></a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#menuSection">About</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#scheduleSection">Schedule</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#mapSection">Venue</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#registerSection">Register</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#speakerSection">Speakers</a>
                 </li>
-                <li class="page-scroll">
+                <li class="page-scroll pull-left">
                     <a href="#accommodationSection">Accommodation</a>
                 </li>
             </ul>

--- a/css/freelancer.css
+++ b/css/freelancer.css
@@ -513,7 +513,8 @@ div.contact-buttons{
 }
 
 img.nav-logo{
-    width: 25%;
+    max-height: 4em;
+    max-width: 100%;
 }
 
 nav {


### PR DESCRIPTION
On smartphones the menu currently can take up half the screen. These changes should greatly reduce that while keeping the navbar links.

Should look the same on desktop browsers.
