### PR TITLE
Closed registration option for Dunedin event

### DIFF
--- a/_posts/2016-02-01-dunedin.html
+++ b/_posts/2016-02-01-dunedin.html
@@ -228,26 +228,16 @@ sponsors:
     <div class="container">
         <div class="row">
             <div class="col-lg-12 text-center">
-                <h1>Come along</h1>
+                <h1>WE'RE FULL</h1>
                 <hr class="star-primary">
             </div>
         </div>
         <div class="row">
             <div class="col-lg-4 col-lg-offset-2">
-                <p>Register here for the {{page.location}} Research Bazaar.</p>
+                <p>We have had a huge response to the Dunedin ResBaz event, and are currently unable to accept any more registrations.</p>
             </div>
             <div class="col-lg-4">
-                <p>The registration process starts with a Pre-Assessment Survey, so that we can create the best possible experience for you. Use the promo code given to you at the end of the survey to complete the registration form.</p>
-            </div>
-            <div class="col-lg-8 col-lg-offset-2 text-center">
-                <div class="col-lg-8 col-lg-offset-2 text-center">
-                    <a href="https://docs.google.com/forms/d/1io9-YyETAl9sQ_NkIjehq4juemgnlaXilG17USHvjug/edit" target = "_blank" class="btn btn-lg btn-outline light-bkg">
-                        <i class="fa fa-pencil"></i> Pre-Assessment Survey
-                    </a>
-                    <a href="https://docs.google.com/forms/d/111HklgzorvMiwQ2gitAux2QQ2NgUR2NBxl80NHjvUL4/edit" target="_blank" class="btn btn-lg btn-outline light-bkg">
-                        <i class="fa fa-users"></i> Register
-                    </a>
-                </div>  
+                <p>If you are interested in attending future ResBaz or Software Carpentry events, please email us at <a href="mailto:res.baz@otago.ac.nz">res.baz@otago.ac.nz</a> and we will notify you of upcoming sessions.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Registration and survey links removed, and replaced with mailto option.
